### PR TITLE
Create ext.properties

### DIFF
--- a/tweener/ext.properties
+++ b/tweener/ext.properties
@@ -1,0 +1,6 @@
+[tweener]
+group = Runtime
+help = Settings for Tweener extension
+
+update_frequency.type = integer
+update_frequency.default = 60


### PR DESCRIPTION
[Soon](https://github.com/defold/defold/pull/11125), it will be possible to show extension settings in the `game.project` form. This PR adds `ext.properties` to show used settings:
<img width="636" height="653" alt="Screenshot 2025-08-22 at 15 59 19" src="https://github.com/user-attachments/assets/a948e847-bc0c-43bc-8171-97dcf1076803" />
