### PR TITLE
Added looping for tween timer

### DIFF
--- a/tweener/tweener.lua
+++ b/tweener/tweener.lua
@@ -23,10 +23,11 @@ local math_min = math.min
 ---@param from number The starting value to tween from
 ---@param to number The target value to tween to
 ---@param time number|nil The duration of the tween in seconds, default is 1
+---@param loop boolean Whether to loop the tween, default is false
 ---@param callback fun(value: number, is_end: boolean) The callback function to call on each update
 ---@param update_delta_time number|nil Default is 1/60, the time between updates
 ---@return tween tween A new created tween state
-function M.tween(easing_function, from, to, time, callback, update_delta_time)
+function M.tween(easing_function, from, to, time, loop, callback, update_delta_time)
 	time = time or 1
 	update_delta_time = update_delta_time or (1 / UPDATE_FREQUENCY)
 
@@ -74,10 +75,15 @@ function M.tween(easing_function, from, to, time, callback, update_delta_time)
 
 		-- If the tween is finished, cancel it and call the callback
 		if time_elapsed >= time then
-			M.cancel(tween)
-			local value = easing_function(time, from, to - from, time)
-			callback(value, true)
-			return
+			if not loop then
+				M.cancel(tween)
+				local value = easing_function(time, from, to - from, time)
+				callback(value, true)
+				return
+			end
+
+			-- Looping: wrap the elapsed time to continue from the start smoothly
+			time_elapsed = time_elapsed % time
 		end
 
 		-- Update the tween and call the callback


### PR DESCRIPTION
I faced the need for an infinite repeating timer, similar to how ```go.animate``` does it with ```go.PLAYBACK_LOOP_FORWARD```.

At first, I tried to recreate the timer on every ```final_call```, but because of timer recreation and some specifics of the Defold engine, I ended up skipping a frame.

```lua
local function get_tween(self, from, to, callback)
	return tweener.tween(consts.CUSTOM_EASING, from, to, consts.ANIMATION_SPEED_IDLE, function(value, is_final_call)
		callback(self, value)

		if is_final_call then
			self.tween = get_tween(self, from, to, callback)
		end
	end)
end
```

https://youtube.com/shorts/_tbI0QzhfFE?si=hhX5-cNtpVy8Bsaw

That’s why there was a need to avoid recreating the timer and instead just “restart” it from the beginning.